### PR TITLE
Add GitHub Actions workflows for PR documentation previews

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,41 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [ closed ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Add cleanup comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          ## 🧹 Documentation Preview Cleanup
+          
+          This PR has been ${{ github.event.pull_request.merged && 'merged' || 'closed' }}. 
+          
+          The documentation preview for PR #${{ github.event.pull_request.number }} has been scheduled for cleanup.
+          
+          **📋 Cleanup Details:**
+          - **PR Number:** #${{ github.event.pull_request.number }}
+          - **Status:** ${{ github.event.pull_request.merged && 'Merged' || 'Closed' }}
+          - **Cleanup Time:** ${{ steps.date.outputs.date }}
+          
+          *Note: Preview artifacts and deployments will be automatically cleaned up according to retention policies.*
+    
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT 

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,97 @@
+name: PR Documentation Preview with Deploy
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  build-and-deploy-preview:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}pr-${{ github.event.number }}/
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+    
+    - name: Install Antora
+      run: npm install -g @antora/cli@3.1 @antora/site-generator@3.1
+    
+    - name: Create cache directory
+      run: mkdir -p ./.cache/antora
+    
+    - name: Build documentation
+      run: |
+        echo "Building Antora documentation..."
+        antora --stacktrace default-site.yml
+    
+    - name: Create PR-specific directory
+      run: |
+        mkdir -p preview/pr-${{ github.event.number }}
+        cp -r www/* preview/pr-${{ github.event.number }}/
+    
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+    
+    - name: Upload to GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: preview/
+    
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+    
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+    
+    - name: Find PR comment
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: 'Documentation Preview'
+    
+    - name: Create or update PR comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        edit-mode: replace
+        body: |
+          ## 📖 Documentation Preview
+          
+          The documentation preview for this PR has been built and deployed successfully!
+          
+          **📋 Preview Details:**
+          - **PR Number:** #${{ github.event.pull_request.number }}
+          - **Commit:** ${{ github.event.pull_request.head.sha }}
+          - **Build Time:** ${{ steps.date.outputs.date }}
+          
+          **🌐 Live Preview:**
+          [**🔗 View Documentation Preview**](${{ steps.deployment.outputs.page_url }}pr-${{ github.event.number }}/)
+          
+          **📥 Alternative - Download Artifact:**
+          You can also download the generated documentation from the [Actions tab](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          
+          **🔄 This comment will be updated automatically when new commits are pushed to this PR.**
+          
+          ---
+          *Preview will be available for 30 days or until the PR is closed.* 


### PR DESCRIPTION
- Add pr-preview-deploy.yml: Builds and deploys Antora documentation to GitHub Pages for each PR
- Add pr-preview-cleanup.yml: Posts cleanup notification when PRs are closed
- PR previews will be available at GitHub Pages URLs with PR-specific paths
- Automatic PR comments with preview links and build status